### PR TITLE
Livraison 2 : Tâche Guiconf , afficher la liste des conférences et ses champs pour édition

### DIFF
--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -82,7 +82,7 @@ public class GuiListConferences {
 		shell.setText("My conference");
 		GridLayout layout = new GridLayout(2, false);
 		shell.setLayout(layout);
-		CreateWidgets();
+		createWidgets();
 		createListenerWidgets();
 		return shell;
 	}
@@ -211,7 +211,12 @@ public class GuiListConferences {
 		}
 	}
 
-	public void CreateWidgets() throws IOException, ParserException, InvalidConferenceFormatException {
+	/**Create widgets of the GUI, and disposition of widgets
+	 * @throws IOException
+	 * @throws ParserException
+	 * @throws InvalidConferenceFormatException
+	 */
+	public void createWidgets() throws IOException, ParserException, InvalidConferenceFormatException {
 		listConferences = new org.eclipse.swt.widgets.List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
 		this.getConferences();
 		GridData gridDatalist = new GridData();
@@ -274,9 +279,9 @@ public class GuiListConferences {
 	 * Create all listener for all widgets of the GUI
 	 */
 	private void createListenerWidgets() {
-		txtCity.addVerifyListener(ListennerAction::CheckTextInput);
-		txtCoutry.addVerifyListener(ListennerAction::CheckTextInput);
-		txtRegisFee.addVerifyListener(ListennerAction::CheckDoubleInput);
+		txtCity.addVerifyListener(ListenerAction::checkTextInput);
+		txtCoutry.addVerifyListener(ListenerAction::checkTextInput);
+		txtRegisFee.addVerifyListener(ListenerAction::checkDoubleInput);
 		listConferences.addListener(SWT.Selection,this::fillInAllFields);
 		btnSave.addListener(SWT.Selection, this::editConference);		
 	}

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -25,26 +25,24 @@ import org.slf4j.LoggerFactory;
 import net.fortuna.ical4j.data.ParserException;
 import com.google.common.primitives.Doubles;
 import com.google.common.base.Strings;
+
 /**
- * @author nikola
- *Gui uses to show a list of conferences of a searcher and with the possibility to edit it
+ * @author nikola Gui 
+ * uses to show a list of conferences of a searcher and with the possibility to edit it
  */
 public class GuiListConferences {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
-	
 	/**
-	 *  Arraylist that stocks all of conferences from ConferenceReader
+	 * List that stocks all of conferences from ConferenceReader
 	 */
-	private ArrayList<Conference> listConferencesUser;
-	
+	private java.util.List<Conference> listConferencesUser;
 	/**
 	 * SWT Widget list, uses for print all conferences
 	 */
 	private List listConferences;
-	
 	private Shell shell;
 	private String calendarName;
-	
 	/**
 	 * SWT Widget text, fields filed fill in by the researcher
 	 */
@@ -55,221 +53,229 @@ public class GuiListConferences {
 	private Text txtCity;
 	private DateTime dateStart;
 	private DateTime dateEnd;
-	
+
 	/**
 	 * Create a GUI where they will have conferences of the user
-	 * @throws ParseException 
-	 * @throws ParserException 
-	 * @throws IOException 
-	 * @throws NumberFormatException 
-	 * @throws InvalidConferenceFormatException 
+	 * 
+	 * @throws ParseException
+	 * @throws ParserException
+	 * @throws IOException
+	 * @throws NumberFormatException
+	 * @throws InvalidConferenceFormatException
 	 */
 	public GuiListConferences() throws IOException, ParserException, InvalidConferenceFormatException {
-		calendarName="threeConferences";
-	    Display display=new Display();
-	    shell=createShell(display);
-	    shell.open();
-
+		calendarName = "threeConferences";
+		Display display = new Display();
+		shell = createShell(display);
+		shell.open();
 	}
-	
-	/** Create a shell with all field of a conference and the list of conferences
-	 * of a specific calendar file
+
+	/**
+	 * Create a shell with all field of a conference and the list of conferences of
+	 * a specific calendar file
+	 * 
 	 * @param display
 	 * @return the shell
 	 * @throws NumberFormatException
 	 * @throws IOException
 	 * @throws ParserException
 	 * @throws ParseException
-	 * @throws InvalidConferenceFormatException 
+	 * @throws InvalidConferenceFormatException
 	 */
 	public Shell createShell(Display display) throws IOException, ParserException, InvalidConferenceFormatException {
-	    this.shell = new Shell(display);
-	    shell.setText("My conference");
-		GridLayout layout = new GridLayout(2,false);
+		this.shell = new Shell(display);
+		shell.setText("My conference");
+		GridLayout layout = new GridLayout(2, false);
 		shell.setLayout(layout);
-		
+
 		listConferences = new List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
-	    this.getConferences();
-	    GridData gridDatalist = new GridData();
-	    gridDatalist.grabExcessHorizontalSpace = true;
-	    gridDatalist.grabExcessVerticalSpace = true;
+		this.getConferences();
+		GridData gridDatalist = new GridData();
+		gridDatalist.grabExcessHorizontalSpace = true;
+		gridDatalist.grabExcessVerticalSpace = true;
 		listConferences.setLayoutData(gridDatalist);
-		
+
 		Group groupInfoConf = new Group(shell, SWT.NONE);
-		groupInfoConf.setText ("Details of your conference");
-		GridLayout gridLayoutDetails=new GridLayout(4, false);
-		groupInfoConf.setLayout (gridLayoutDetails);
-		
-		GridData gridDataTextField=new GridData();
-		gridDataTextField.horizontalSpan=3;
+		groupInfoConf.setText("Details of your conference");
+		GridLayout gridLayoutDetails = new GridLayout(4, false);
+		groupInfoConf.setLayout(gridLayoutDetails);
+
+		GridData gridDataTextField = new GridData();
+		gridDataTextField.horizontalSpan = 3;
 		gridDataTextField.widthHint = 500;
 		gridDataTextField.heightHint = 30;
-		
-		Label labelTitle= new Label(groupInfoConf, SWT.NONE);
+
+		Label labelTitle = new Label(groupInfoConf, SWT.NONE);
 		labelTitle.setText("Title :");
-		this.txtTitle = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtTitle = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
 		this.txtTitle.setLayoutData(gridDataTextField);
-		
-		Label labelUrl= new Label(groupInfoConf, SWT.NONE);
+
+		Label labelUrl = new Label(groupInfoConf, SWT.NONE);
 		labelUrl.setText("URL :");
-		this.txtUrl = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtUrl = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
 		this.txtUrl.setLayoutData(gridDataTextField);
-		
-		Label labelFee= new Label(groupInfoConf, SWT.NONE);
+
+		Label labelFee = new Label(groupInfoConf, SWT.NONE);
 		labelFee.setText("Fee :");
-		this.txtRegisFee = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtRegisFee = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
 		this.txtRegisFee.setLayoutData(gridDataTextField);
-		
-		Label labelCountry= new Label(groupInfoConf, SWT.NONE);
+
+		Label labelCountry = new Label(groupInfoConf, SWT.NONE);
 		labelCountry.setText("Country :");
-		this.txtCoutry = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtCoutry = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
 		this.txtCoutry.setLayoutData(gridDataTextField);
-		
+
 		Label labelCity = new Label(groupInfoConf, SWT.NONE);
 		labelCity.setText("City :");
-		this.txtCity=new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtCity = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
 		this.txtCity.setLayoutData(gridDataTextField);
-		
+
 		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
 		labelDateStart.setText("Date start :");
-		this.dateStart=new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateStart = new DateTime(groupInfoConf, SWT.DEFAULT);
 		this.dateStart.setLayoutData(gridDataTextField);
 
 		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
 		labelDateEnd.setText("Date end :");
-		this.dateEnd=new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateEnd = new DateTime(groupInfoConf, SWT.DEFAULT);
 		this.dateEnd.setLayoutData(gridDataTextField);
-		
-		Button btnSave=new Button(groupInfoConf, SWT.PUSH);
+
+		Button btnSave = new Button(groupInfoConf, SWT.PUSH);
 		btnSave.setText("Save Conference");
 		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
 		btnSave.setLayoutData(gridDataBtn);
-	
-		VerifyListener verifyListenerLetter=new VerifyListener() {
-			
+
+		VerifyListener verifyListenerLetter = new VerifyListener() {
 			/**
-			 *check if the character is a letter or "-" or a whitespace, 
-			 *if not you can't put the character
+			 * check if the character is a letter or "-" or a whitespace, if not you can't
+			 * put the character
 			 */
 			@Override
 			public void verifyText(VerifyEvent e) {
 				if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
-					e.doit=false;
+					e.doit = false;
 				}
 			}
 		};
-		
+
 		txtCity.addVerifyListener(verifyListenerLetter);
 		txtCoutry.addVerifyListener(verifyListenerLetter);
-		
+
 		txtRegisFee.addVerifyListener(new VerifyListener() {
-			
+
 			/**
-			 *check that the fee is a double, if not you can't put the character
+			 * check that the fee is a double, if not you can't put the character
 			 */
 			@Override
 			public void verifyText(VerifyEvent e) {
-				if (Doubles.tryParse(txtRegisFee.getText()+e.text)==null) {
-					e.doit=false;
-				}				
+				if (Doubles.tryParse(txtRegisFee.getText() + e.text) == null) {
+					e.doit = false;
+				}
 			}
 		});
-		
+
 		listConferences.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				if (listConferences.getSelectionIndex()>=0) {
+				if (listConferences.getSelectionIndex() >= 0) {
 					Conference conferenceSelected;
-					conferenceSelected=listConferencesUser.get(listConferences.getSelectionIndex());
+					conferenceSelected = listConferencesUser.get(listConferences.getSelectionIndex());
 					txtTitle.setText(conferenceSelected.getTitle());
 					txtCity.setText(conferenceSelected.getCity());
 					txtCoutry.setText(conferenceSelected.getCountry());
 					txtUrl.setText(conferenceSelected.getUrl().toString());
 					txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
-					setDateofConferences(dateStart,conferenceSelected.getStartDate());
-					setDateofConferences(dateEnd,conferenceSelected.getEndDate());
+					setDateofConferences(dateStart, conferenceSelected.getStartDate());
+					setDateofConferences(dateEnd, conferenceSelected.getEndDate());
 				}
 			}
-			
+
 			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
+				widgetSelected(e);
 			}
-			
+
 		});
-		
+
 		btnSave.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				
-				//edit of a conference
-				if(isAllFieldsValid() && listConferences.getSelectionIndex()>=0) {
-					//ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
-					//ConferenceWriter.addConference(calendarName,new Conference(.........));
+
+				// edit of a conference
+				if (isAllFieldsValid() && listConferences.getSelectionIndex() >= 0) {
+					// ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
+					// ConferenceWriter.addConference(calendarName,new Conference(.........));
 					listConferences.removeAll();
 					try {
 						getConferences();
-					} catch (IOException | ParserException|InvalidConferenceFormatException e1) {
-						e1.printStackTrace();
+					} catch (IOException | ParserException | InvalidConferenceFormatException e1) {
+						throw new IllegalStateException(e1);
 					}
 				}
 			}
+
 			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {				
+			public void widgetDefaultSelected(SelectionEvent e) {
+				widgetSelected(e);
 			}
 		});
-		
+
 		return shell;
 	}
-	
+
 	/**
 	 * this method display the GUI in a windows
 	 */
 	public void display() {
 		this.shell.pack();
 		this.shell.open();
-		while (!this.shell.isDisposed())
-		{
+		while (!this.shell.isDisposed()) {
 			if (!shell.getDisplay().readAndDispatch()) {
 				shell.getDisplay().sleep();
 			}
 		}
 	}
-		
+
 	/**
-	 * We retrieve the conferences stored in the iCalendar file of the searcher
-	 * and display it in a SWT widget list 
+	 * We retrieve the conferences stored in the iCalendar file of the searcher and
+	 * display it in a SWT widget list
+	 * 
 	 * @throws NumberFormatException
 	 * @throws IOException
 	 * @throws ParserException
 	 * @throws ParseException
-	 * @throws InvalidConferenceFormatException 
+	 * @throws InvalidConferenceFormatException
 	 */
 	public void getConferences() throws IOException, ParserException, InvalidConferenceFormatException {
 		ConferencesRetriever retriever = new ConferencesFromICal();
-		ConferencesShower conflist=new ConferencesShower(retriever);
-		listConferencesUser=new ArrayList<Conference>(conflist.searchConferenceInFile(this.calendarName));
-	    for (Conference conf: this.listConferencesUser) {
-	      listConferences.add(conf.getTitle());
-	    }
+		ConferencesShower conflist = new ConferencesShower(retriever);
+		listConferencesUser = new ArrayList<>(conflist.searchConferenceInFile(this.calendarName));
+		for (Conference conf : this.listConferencesUser) {
+			listConferences.add(conf.getTitle());
+		}
 	}
-	
-	/** this method change the date of a conference 
-	 * in the good format in the widget Datetime of the GUI
+
+	/**
+	 * this method change the date of a conference in the good format in the widget
+	 * Datetime of the GUI
+	 * 
 	 * @param fieldDate field of the GUI
-	 * @param dateRead date of the conference
+	 * @param dateRead  date of the conference
 	 */
-	public void setDateofConferences(DateTime fieldDate,LocalDate dateRead) {
-		fieldDate.setDate(dateRead.getYear(), dateRead.getMonthValue()-1, dateRead.getDayOfMonth());
+	public void setDateofConferences(DateTime fieldDate, LocalDate dateRead) {
+		fieldDate.setDate(dateRead.getYear(), dateRead.getMonthValue() - 1, dateRead.getDayOfMonth());
 	}
-	
-	/**This method check the validity of a date choose by the searcher :
-	 * Date of start must be < of Date of End 
+
+	/**
+	 * This method check the validity of a date choose by the searcher : Date of
+	 * start must be < of Date of End
+	 * 
 	 * @return
 	 */
 	public boolean isDateValid() {
-		LocalDate localDateStart=LocalDate.of(dateStart.getYear(), dateStart.getMonth()+1, dateStart.getDay());
-		LocalDate localDateEnd=LocalDate.of(dateEnd.getYear(), dateEnd.getMonth()+1, dateEnd.getDay());
-		if (localDateStart.compareTo(localDateEnd)>=0) {
+		LocalDate localDateStart = LocalDate.of(dateStart.getYear(), dateStart.getMonth() + 1, dateStart.getDay());
+		LocalDate localDateEnd = LocalDate.of(dateEnd.getYear(), dateEnd.getMonth() + 1, dateEnd.getDay());
+		if (localDateStart.compareTo(localDateEnd) >= 0) {
 			LOGGER.debug("Conference not save : start day >= end day");
 			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
 			mb.setText("Failed");
@@ -279,17 +285,17 @@ public class GuiListConferences {
 		}
 		return true;
 	}
-	
-	/** Check that all text fields are filled
+
+	/**
+	 * Check that all text fields are filled
+	 * 
 	 * @return a boolean that say if all fields are filled
 	 */
 	public boolean isFillIn() {
-		if((Strings.isNullOrEmpty(txtCity.getText())
-				||Strings.isNullOrEmpty(txtUrl.getText())
-				||Strings.isNullOrEmpty(txtCoutry.getText())
-				||Strings.isNullOrEmpty(txtTitle.getText())
-				||Strings.isNullOrEmpty(txtRegisFee.getText()))){
-			
+		if ((Strings.isNullOrEmpty(txtCity.getText()) || Strings.isNullOrEmpty(txtUrl.getText())
+				|| Strings.isNullOrEmpty(txtCoutry.getText()) || Strings.isNullOrEmpty(txtTitle.getText())
+				|| Strings.isNullOrEmpty(txtRegisFee.getText()))) {
+
 			LOGGER.debug("Conference not save : not all fields filled");
 			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
 			mb.setText("Failed");
@@ -299,17 +305,17 @@ public class GuiListConferences {
 		}
 		return true;
 	}
-	
-	/** launch all method that check if all fields are filled correctly
+
+	/**
+	 * Launch all method that check if all fields are filled correctly
+	 * 
 	 * @return a boolean that say if all is correct or not
 	 */
 	public boolean isAllFieldsValid() {
-		return isDateValid()&&isFillIn();
+		return isDateValid() && isFillIn();
 	}
-	
-	public static void main(String[]args) throws IOException, ParserException, InvalidConferenceFormatException{
+
+	public static void main(String[] args) throws IOException, ParserException, InvalidConferenceFormatException {
 		new GuiListConferences().display();
 	}
 }
-
-

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -15,8 +15,10 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
@@ -28,7 +30,7 @@ import com.google.common.base.Strings;
 
 /**
  * @author nikola 
- * This class Gui uses to show a list of conferences of a searcher 
+ * This class GUI uses to show a list of conferences of a searcher 
  * and with the possibility to edit it
  */
 public class GuiListConferences {
@@ -54,6 +56,7 @@ public class GuiListConferences {
 	private Text txtCity;
 	private DateTime dateStart;
 	private DateTime dateEnd;
+	private Button btnSave;
 
 	public GuiListConferences() throws IOException, ParserException, InvalidConferenceFormatException {
 		calendarName = "threeConferences";
@@ -79,112 +82,8 @@ public class GuiListConferences {
 		shell.setText("My conference");
 		GridLayout layout = new GridLayout(2, false);
 		shell.setLayout(layout);
-
-		listConferences = new org.eclipse.swt.widgets.List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
-		this.getConferences();
-		GridData gridDatalist = new GridData();
-		gridDatalist.grabExcessHorizontalSpace = true;
-		gridDatalist.grabExcessVerticalSpace = true;
-		listConferences.setLayoutData(gridDatalist);
-
-		Group groupInfoConf = new Group(shell, SWT.NONE);
-		groupInfoConf.setText("Details of your conference");
-		GridLayout gridLayoutDetails = new GridLayout(4, false);
-		groupInfoConf.setLayout(gridLayoutDetails);
-
-		GridData gridDataTextField = new GridData();
-		gridDataTextField.horizontalSpan = 3;
-		gridDataTextField.widthHint = 500;
-		gridDataTextField.heightHint = 30;
-
-		Label labelTitle = new Label(groupInfoConf, SWT.NONE);
-		labelTitle.setText("Title :");
-		this.txtTitle = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
-		this.txtTitle.setLayoutData(gridDataTextField);
-
-		Label labelUrl = new Label(groupInfoConf, SWT.NONE);
-		labelUrl.setText("URL :");
-		this.txtUrl = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
-		this.txtUrl.setLayoutData(gridDataTextField);
-
-		Label labelFee = new Label(groupInfoConf, SWT.NONE);
-		labelFee.setText("Fee :");
-		this.txtRegisFee = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
-		this.txtRegisFee.setLayoutData(gridDataTextField);
-
-		Label labelCountry = new Label(groupInfoConf, SWT.NONE);
-		labelCountry.setText("Country :");
-		this.txtCoutry = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
-		this.txtCoutry.setLayoutData(gridDataTextField);
-
-		Label labelCity = new Label(groupInfoConf, SWT.NONE);
-		labelCity.setText("City :");
-		this.txtCity = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
-		this.txtCity.setLayoutData(gridDataTextField);
-
-		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
-		labelDateStart.setText("Date start :");
-		this.dateStart = new DateTime(groupInfoConf, SWT.DEFAULT);
-		this.dateStart.setLayoutData(gridDataTextField);
-
-		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
-		labelDateEnd.setText("Date end :");
-		this.dateEnd = new DateTime(groupInfoConf, SWT.DEFAULT);
-		this.dateEnd.setLayoutData(gridDataTextField);
-
-		Button btnSave = new Button(groupInfoConf, SWT.PUSH);
-		btnSave.setText("Save Conference");
-		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
-		btnSave.setLayoutData(gridDataBtn);
-
-		txtCity.addVerifyListener(ListennerAction::CheckTextInput);
-		txtCoutry.addVerifyListener(ListennerAction::CheckTextInput);
-		txtRegisFee.addVerifyListener(ListennerAction::CheckDoubleInput);
-		listConferences.addSelectionListener(new SelectionListener() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (listConferences.getSelectionIndex() >= 0) {
-					Conference conferenceSelected;
-					conferenceSelected = listConferencesUser.get(listConferences.getSelectionIndex());
-					txtTitle.setText(conferenceSelected.getTitle());
-					txtCity.setText(conferenceSelected.getCity());
-					txtCoutry.setText(conferenceSelected.getCountry());
-					txtUrl.setText(conferenceSelected.getUrl().toString());
-					txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
-					setDateofConferences(dateStart, conferenceSelected.getStartDate());
-					setDateofConferences(dateEnd, conferenceSelected.getEndDate());
-				}
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				widgetSelected(e);
-			}
-
-		});
-
-		btnSave.addSelectionListener(new SelectionListener() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-
-				/* edit of a conference: delete and save the conference edited */
-				if (isAllFieldsValid() && listConferences.getSelectionIndex() >= 0) {
-					LOGGER.warn("Save of Conference not yet implemented");
-					listConferences.removeAll();
-					try {
-						getConferences();
-					} catch (IOException | ParserException | InvalidConferenceFormatException e1) {
-						throw new IllegalStateException(e1);
-					}
-				}
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				widgetSelected(e);
-			}
-		});
-
+		CreateWidgets();
+		createListenerWidgets();
 		return shell;
 	}
 
@@ -222,7 +121,7 @@ public class GuiListConferences {
 
 	/**
 	 * this method change the date of a conference in the good format in the widget
-	 * Datetime of the GUI
+	 * Date time of the GUI
 	 * 
 	 * @param fieldDate field of the GUI
 	 * @param dateRead  date of the conference
@@ -279,7 +178,109 @@ public class GuiListConferences {
 	public boolean isAllFieldsValid() {
 		return isDateValid() && isFillIn();
 	}
+	
+	/** Fill all fields of the GUI with the information of a conference
+	 * @param e event that we catch
+	 */
+	public void fillInAllFields(Event e) {
+		if (listConferences.getSelectionIndex() >= 0) {
+			Conference conferenceSelected;
+			conferenceSelected = listConferencesUser.get(listConferences.getSelectionIndex());
+			txtTitle.setText(conferenceSelected.getTitle());
+			txtCity.setText(conferenceSelected.getCity());
+			txtCoutry.setText(conferenceSelected.getCountry());
+			txtUrl.setText(conferenceSelected.getUrl().toString());
+			txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
+			setDateofConferences(dateStart, conferenceSelected.getStartDate());
+			setDateofConferences(dateEnd, conferenceSelected.getEndDate());
+		}
+	}
+	
+	/** Edit of a conference: delete and save the conference edited
+	 * @param e event that we catch
+	 */
+	public void editConference(Event e) {
+		if (isAllFieldsValid() && listConferences.getSelectionIndex() >= 0) {
+			LOGGER.warn("Save of Conference not yet implemented");
+			listConferences.removeAll();
+			try {
+				getConferences();
+			} catch (IOException | ParserException | InvalidConferenceFormatException e1) {
+				throw new IllegalStateException(e1);
+			}
+		}
+	}
 
+	public void CreateWidgets() throws IOException, ParserException, InvalidConferenceFormatException {
+		listConferences = new org.eclipse.swt.widgets.List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
+		this.getConferences();
+		GridData gridDatalist = new GridData();
+		gridDatalist.grabExcessHorizontalSpace = true;
+		gridDatalist.grabExcessVerticalSpace = true;
+		listConferences.setLayoutData(gridDatalist);
+
+		Group groupInfoConf = new Group(shell, SWT.NONE);
+		groupInfoConf.setText("Details of your conference");
+		GridLayout gridLayoutDetails = new GridLayout(4, false);
+		groupInfoConf.setLayout(gridLayoutDetails);
+
+		GridData gridDataTextField = new GridData();
+		gridDataTextField.horizontalSpan = 3;
+		gridDataTextField.widthHint = 500;
+		gridDataTextField.heightHint = 30;
+
+		Label labelTitle = new Label(groupInfoConf, SWT.NONE);
+		labelTitle.setText("Title :");
+		this.txtTitle = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
+		this.txtTitle.setLayoutData(gridDataTextField);
+
+		Label labelUrl = new Label(groupInfoConf, SWT.NONE);
+		labelUrl.setText("URL :");
+		this.txtUrl = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
+		this.txtUrl.setLayoutData(gridDataTextField);
+
+		Label labelFee = new Label(groupInfoConf, SWT.NONE);
+		labelFee.setText("Fee :");
+		this.txtRegisFee = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
+		this.txtRegisFee.setLayoutData(gridDataTextField);
+
+		Label labelCountry = new Label(groupInfoConf, SWT.NONE);
+		labelCountry.setText("Country :");
+		this.txtCoutry = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
+		this.txtCoutry.setLayoutData(gridDataTextField);
+
+		Label labelCity = new Label(groupInfoConf, SWT.NONE);
+		labelCity.setText("City :");
+		this.txtCity = new Text(groupInfoConf, SWT.SINGLE | SWT.BORDER);
+		this.txtCity.setLayoutData(gridDataTextField);
+
+		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
+		labelDateStart.setText("Date start :");
+		this.dateStart = new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateStart.setLayoutData(gridDataTextField);
+
+		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
+		labelDateEnd.setText("Date end :");
+		this.dateEnd = new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateEnd.setLayoutData(gridDataTextField);
+
+		btnSave = new Button(groupInfoConf, SWT.PUSH);
+		btnSave.setText("Save Conference");
+		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
+		btnSave.setLayoutData(gridDataBtn);
+	}
+	
+	/**
+	 * Create all listener for all widgets of the GUI
+	 */
+	private void createListenerWidgets() {
+		txtCity.addVerifyListener(ListennerAction::CheckTextInput);
+		txtCoutry.addVerifyListener(ListennerAction::CheckTextInput);
+		txtRegisFee.addVerifyListener(ListennerAction::CheckDoubleInput);
+		listConferences.addListener(SWT.Selection,this::fillInAllFields);
+		btnSave.addListener(SWT.Selection, this::editConference);		
+	}
+	
 	public static void main(String[] args) throws IOException, ParserException, InvalidConferenceFormatException {
 		new GuiListConferences().display();
 	}

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -137,35 +137,9 @@ public class GuiListConferences {
 		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
 		btnSave.setLayoutData(gridDataBtn);
 
-		VerifyListener verifyListenerLetter = new VerifyListener() {
-			/**
-			 * check if the character is a letter or "-" or a whitespace, if not you can't
-			 * put the character
-			 */
-			@Override
-			public void verifyText(VerifyEvent e) {
-				if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
-					e.doit = false;
-				}
-			}
-		};
-
-		txtCity.addVerifyListener(verifyListenerLetter);
-		txtCoutry.addVerifyListener(verifyListenerLetter);
-
-		txtRegisFee.addVerifyListener(new VerifyListener() {
-
-			/**
-			 * check that the fee is a double, if not you can't put the character
-			 */
-			@Override
-			public void verifyText(VerifyEvent e) {
-				if (Doubles.tryParse(txtRegisFee.getText() + e.text) == null) {
-					e.doit = false;
-				}
-			}
-		});
-
+		txtCity.addVerifyListener(ListennerAction::CheckTextInput);
+		txtCoutry.addVerifyListener(ListennerAction::CheckTextInput);
+		txtRegisFee.addVerifyListener(ListennerAction::CheckDoubleInput);
 		listConferences.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -248,10 +248,10 @@ public class GuiListConferences {
 	
 	/** this method implement the date of a conference in the good format in the GUI
 	 * @param fieldDate field of the GUI
-	 * @param dateread date of the conference
+	 * @param dateRead date of the conference
 	 */
-	public void setDateofConferences(DateTime fieldDate,LocalDate dateread) {
-		fieldDate.setDate(dateread.getYear(), dateread.getMonthValue()-1, dateread.getDayOfMonth());
+	public void setDateofConferences(DateTime fieldDate,LocalDate dateRead) {
+		fieldDate.setDate(dateRead.getYear(), dateRead.getMonthValue()-1, dateRead.getDayOfMonth());
 	}
 	
 	/**This method check the validity of date choose by the searcher :

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.fortuna.ical4j.data.ParserException;
 import com.google.common.primitives.Doubles;
+import com.google.common.base.Strings;
 /**
  * @author nikola
  *Gui where we can show conferences of a user
@@ -34,7 +35,18 @@ public class GuiListConferences {
 	private List listConferences;
 	private Shell shell;
 	private String calendarName;
-
+	
+	/**
+	 * fields filed fill in by the researcher
+	 */
+	private Text txtTitle;
+	private Text txtUrl;
+	private Text txtRegisFee;
+	private Text txtCoutry;
+	private Text txtCity;
+	private DateTime dateStart;
+	private DateTime dateEnd;
+	
 	/**
 	 * Create a GUI where they will have conferences of the user
 	 * @throws ParseException 
@@ -51,7 +63,7 @@ public class GuiListConferences {
 
 	}
 	
-	/** Create a shell with all field of a conference and a list of conferences
+	/** Create a shell with all field of a conference and the list of conferences
 	 * of a file
 	 * @param display
 	 * @return the shell
@@ -86,38 +98,38 @@ public class GuiListConferences {
 		
 		Label labelTitle= new Label(groupInfoConf, SWT.NONE);
 		labelTitle.setText("Title :");
-		Text txtTitle = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtTitle.setLayoutData(gridDataTextField);
+		this.txtTitle = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtTitle.setLayoutData(gridDataTextField);
 		
 		Label labelUrl= new Label(groupInfoConf, SWT.NONE);
 		labelUrl.setText("URL :");
-		Text txtUrl = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtUrl.setLayoutData(gridDataTextField);
+		this.txtUrl = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtUrl.setLayoutData(gridDataTextField);
 		
 		Label labelFee= new Label(groupInfoConf, SWT.NONE);
 		labelFee.setText("Fee :");
-		Text txtRegisFee = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtRegisFee.setLayoutData(gridDataTextField);
+		this.txtRegisFee = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtRegisFee.setLayoutData(gridDataTextField);
 		
 		Label labelCountry= new Label(groupInfoConf, SWT.NONE);
 		labelCountry.setText("Country :");
-		Text txtCoutry = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtCoutry.setLayoutData(gridDataTextField);
+		this.txtCoutry = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtCoutry.setLayoutData(gridDataTextField);
 		
 		Label labelCity = new Label(groupInfoConf, SWT.NONE);
 		labelCity.setText("City :");
-		Text txtCity=new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtCity.setLayoutData(gridDataTextField);
+		this.txtCity=new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		this.txtCity.setLayoutData(gridDataTextField);
 		
 		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
 		labelDateStart.setText("Date start :");
-		DateTime dateStart=new DateTime(groupInfoConf, SWT.DEFAULT);
-		dateStart.setLayoutData(gridDataTextField);
+		this.dateStart=new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateStart.setLayoutData(gridDataTextField);
 
 		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
 		labelDateEnd.setText("Date end :");
-		DateTime dateEnd=new DateTime(groupInfoConf, SWT.DEFAULT);
-		dateEnd.setLayoutData(gridDataTextField);
+		this.dateEnd=new DateTime(groupInfoConf, SWT.DEFAULT);
+		this.dateEnd.setLayoutData(gridDataTextField);
 		
 		Button btnSave=new Button(groupInfoConf, SWT.PUSH);
 		btnSave.setText("Save Conference");
@@ -126,6 +138,9 @@ public class GuiListConferences {
 	
 		VerifyListener verifyListenerLetter=new VerifyListener() {
 			
+			/**
+			 *check if the character is a letter or - or a whitespace
+			 */
 			@Override
 			public void verifyText(VerifyEvent e) {
 				if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
@@ -161,8 +176,8 @@ public class GuiListConferences {
 					txtCoutry.setText(conferenceSelected.getCountry());
 					txtUrl.setText(conferenceSelected.getUrl().toString());
 					txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
-					setDateofConf(dateStart,conferenceSelected.getStartDate());
-					setDateofConf(dateEnd,conferenceSelected.getEndDate());
+					setDateofConferences(dateStart,conferenceSelected.getStartDate());
+					setDateofConferences(dateEnd,conferenceSelected.getEndDate());
 				}
 			}
 			
@@ -177,22 +192,19 @@ public class GuiListConferences {
 			public void widgetSelected(SelectionEvent e) {
 				
 				//edit of a conference
-				if(isDateValid(dateStart, dateEnd)&& listConferences.getSelectionIndex()>=0) {
+				if(isAllFieldsValid() && listConferences.getSelectionIndex()>=0) {
 					//dev by other team
 					//ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
 					//ConferenceWriter.addConference(calendarName,new Conference(.........));
 					listConferences.removeAll();
 					try {
 						getConferences();
-					} catch (NumberFormatException | IOException | ParserException|InvalidConferenceFormatException e1) {
+					} catch (IOException | ParserException|InvalidConferenceFormatException e1) {
 						e1.printStackTrace();
 					}
 				}
 				else {
-					MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
-					mb.setText("Failed");
-					mb.setMessage("Date Start can't be lower or equal to Date End");
-					mb.open();
+
 				}
 			}
 			@Override
@@ -238,24 +250,54 @@ public class GuiListConferences {
 	 * @param fieldDate field of the GUI
 	 * @param dateread date of the conference
 	 */
-	public void setDateofConf(DateTime fieldDate,LocalDate dateread) {
+	public void setDateofConferences(DateTime fieldDate,LocalDate dateread) {
 		fieldDate.setDate(dateread.getYear(), dateread.getMonthValue()-1, dateread.getDayOfMonth());
 	}
 	
 	/**This method check the validity of date choose by the searcher :
 	 * Date of start < of Date of End 
-	 * @param datestart field that contains the start date of the conference
-	 * @param dateend field that contains the end date of the conference
 	 * @return
 	 */
-	public boolean isDateValid(DateTime datestart,DateTime dateend) {
-		LocalDate localDateStart=LocalDate.of(datestart.getYear(), datestart.getMonth()+1, datestart.getDay());
-		LocalDate localDateEnd=LocalDate.of(dateend.getYear(), dateend.getMonth()+1, dateend.getDay());
+	public boolean isDateValid() {
+		LocalDate localDateStart=LocalDate.of(dateStart.getYear(), dateStart.getMonth()+1, dateStart.getDay());
+		LocalDate localDateEnd=LocalDate.of(dateEnd.getYear(), dateEnd.getMonth()+1, dateEnd.getDay());
 		if (localDateStart.compareTo(localDateEnd)>=0) {
-			LOGGER.debug("conference not save : start day >= end day");
+			LOGGER.debug("Conference not save : start day >= end day");
+			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
+			mb.setText("Failed");
+			mb.setMessage("Date Start can't be lower or equal to Date End");
+			mb.open();
 			return false;
 		}
 		return true;
+	}
+	
+	/** Check that all text fields are fill in
+	 * @return a boolean that say if all fields are fill
+	 */
+	public boolean isFillIn() {
+		
+		if((Strings.isNullOrEmpty(txtCity.getText())
+				||Strings.isNullOrEmpty(txtUrl.getText())
+				||Strings.isNullOrEmpty(txtCoutry.getText())
+				||Strings.isNullOrEmpty(txtTitle.getText())
+				||Strings.isNullOrEmpty(txtRegisFee.getText()))){
+			
+			LOGGER.debug("conference not save : not all fields filled");
+			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
+			mb.setText("Failed");
+			mb.setMessage("Conference not save : not all fields filled");
+			mb.open();
+			return false;
+		}
+		return true;
+	}
+	
+	/** launch all method that check if all fields are filled in correctly
+	 * @return a boolean that say if all is correct or not
+	 */
+	public boolean isAllFieldsValid() {
+		return isDateValid()&&isFillIn();
 	}
 	
 	public static void main(String[]args) throws IOException, ParserException, InvalidConferenceFormatException{

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -124,6 +124,19 @@ public class GuiListConferences {
 		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
 		btnSave.setLayoutData(gridDataBtn);
 	
+		VerifyListener verifyListenerLetter=new VerifyListener() {
+			
+			@Override
+			public void verifyText(VerifyEvent e) {
+				if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
+					e.doit=false;
+				}
+			}
+		};
+		
+		txtCity.addVerifyListener(verifyListenerLetter);
+		txtCoutry.addVerifyListener(verifyListenerLetter);
+		
 		txtRegisFee.addVerifyListener(new VerifyListener() {
 			
 			/**

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -70,8 +70,6 @@ public class GuiListConferences {
 	    GridData gridDatalist = new GridData();
 	    gridDatalist.grabExcessHorizontalSpace = true;
 	    gridDatalist.grabExcessVerticalSpace = true;
-	    //gridDatalist.widthHint = 550;
-	    //gridDatalist.heightHint = 150;
 		listConferences.setLayoutData(gridDatalist);
 		
 		Group groupInfoConf = new Group(shell, SWT.NONE);
@@ -79,50 +77,50 @@ public class GuiListConferences {
 		GridLayout gridLayoutDetails=new GridLayout(4, false);
 		groupInfoConf.setLayout (gridLayoutDetails);
 		
-		GridData gridData=new GridData();
-		gridData.horizontalSpan=3;
-		gridData.widthHint = 500;
-		gridData.heightHint = 30;
+		GridData gridDataTextField=new GridData();
+		gridDataTextField.horizontalSpan=3;
+		gridDataTextField.widthHint = 500;
+		gridDataTextField.heightHint = 30;
 		
 		Label labelTitle= new Label(groupInfoConf, SWT.NONE);
 		labelTitle.setText("Title :");
 		Text txtTitle = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtTitle.setLayoutData(gridData);
+		txtTitle.setLayoutData(gridDataTextField);
 		
 		Label labelUrl= new Label(groupInfoConf, SWT.NONE);
 		labelUrl.setText("URL :");
 		Text txtUrl = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtUrl.setLayoutData(gridData);
+		txtUrl.setLayoutData(gridDataTextField);
 		
-		Label labelfee= new Label(groupInfoConf, SWT.NONE);
-		labelfee.setText("Fee :");
+		Label labelFee= new Label(groupInfoConf, SWT.NONE);
+		labelFee.setText("Fee :");
 		Text txtRegisFee = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtRegisFee.setLayoutData(gridData);
+		txtRegisFee.setLayoutData(gridDataTextField);
 		
 		Label labelCountry= new Label(groupInfoConf, SWT.NONE);
 		labelCountry.setText("Country :");
 		Text txtCoutry = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtCoutry.setLayoutData(gridData);
+		txtCoutry.setLayoutData(gridDataTextField);
 		
 		Label labelCity = new Label(groupInfoConf, SWT.NONE);
 		labelCity.setText("City :");
 		Text txtCity=new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
-		txtCity.setLayoutData(gridData);
+		txtCity.setLayoutData(gridDataTextField);
 		
 		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
 		labelDateStart.setText("Date start :");
-		DateTime datestart=new DateTime(groupInfoConf, SWT.DEFAULT);
-		datestart.setLayoutData(gridData);
+		DateTime dateStart=new DateTime(groupInfoConf, SWT.DEFAULT);
+		dateStart.setLayoutData(gridDataTextField);
 
 		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
 		labelDateEnd.setText("Date end :");
-		DateTime dateend=new DateTime(groupInfoConf, SWT.DEFAULT);
-		dateend.setLayoutData(gridData);
+		DateTime dateEnd=new DateTime(groupInfoConf, SWT.DEFAULT);
+		dateEnd.setLayoutData(gridDataTextField);
 		
-		Button btnsave=new Button(groupInfoConf, SWT.PUSH);
-		btnsave.setText("Save Conference");
+		Button btnSave=new Button(groupInfoConf, SWT.PUSH);
+		btnSave.setText("Save Conference");
 		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
-		btnsave.setLayoutData(gridDataBtn);
+		btnSave.setLayoutData(gridDataBtn);
 	
 
 		listConferences.addSelectionListener(new SelectionListener() {
@@ -136,8 +134,8 @@ public class GuiListConferences {
 					txtCoutry.setText(conferenceSelected.getCountry());
 					txtUrl.setText(conferenceSelected.getUrl().toString());
 					txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
-					setDateofConf(datestart,conferenceSelected.getStartDate());
-					setDateofConf(dateend,conferenceSelected.getEndDate());
+					setDateofConf(dateStart,conferenceSelected.getStartDate());
+					setDateofConf(dateEnd,conferenceSelected.getEndDate());
 				}
 			}
 			
@@ -147,12 +145,13 @@ public class GuiListConferences {
 			
 		});
 		
-		btnsave.addSelectionListener(new SelectionListener() {
+		btnSave.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				
 				//edit of a conference
-				if(isDateValid(datestart, dateend)&& listConferences.getSelectionIndex()>=0) {
+				if(isDateValid(dateStart, dateEnd)&& listConferences.getSelectionIndex()>=0) {
+					//dev by other team
 					//ConferenceWriter.deleteConference(listConferencesUser.get(listConferences.getSelectionIndex()));
 					//ConferenceWriter.addConference(new conference(.........));
 					listConferences.removeAll();
@@ -161,6 +160,12 @@ public class GuiListConferences {
 					} catch (NumberFormatException | IOException | ParserException|InvalidConferenceFormatException e1) {
 						e1.printStackTrace();
 					}
+				}
+				else {
+					MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
+					mb.setText("Failed");
+					mb.setMessage("Date Start can't be lower or equal to Date End");
+					mb.open();
 				}
 			}
 			@Override
@@ -217,14 +222,10 @@ public class GuiListConferences {
 	 * @return
 	 */
 	public boolean isDateValid(DateTime datestart,DateTime dateend) {
-		LocalDate lstart=LocalDate.of(datestart.getYear(), datestart.getMonth()+1, datestart.getDay());
-		LocalDate leend=LocalDate.of(dateend.getYear(), dateend.getMonth()+1, dateend.getDay());
-		if (lstart.compareTo(leend)>0||lstart.compareTo(leend)==0) {
-			LOGGER.debug("conference not save : startday > enday");
-			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
-			mb.setText("Failed");
-			mb.setMessage("Date Start can't be lower or equal to Date End");
-			mb.open();
+		LocalDate localDateStart=LocalDate.of(datestart.getYear(), datestart.getMonth()+1, datestart.getDay());
+		LocalDate localDateEnd=LocalDate.of(dateend.getYear(), dateend.getMonth()+1, dateend.getDay());
+		if (localDateStart.compareTo(localDateEnd)>=0) {
+			LOGGER.debug("conference not save : start day >= end day");
 			return false;
 		}
 		return true;

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -2,13 +2,24 @@ package io.github.oliviercailloux.y2018.jconfs;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.Set;
-
+import java.time.LocalDate;
+import java.util.ArrayList;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.List;
+import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import net.fortuna.ical4j.data.ParserException;
 
 /**
@@ -16,30 +27,148 @@ import net.fortuna.ical4j.data.ParserException;
  *Gui where we can show conferences of a user
  */
 public class GuiListConferences {
+	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
+	private ArrayList<Conference> listConferencesUser;
+	private List listConferences;
+	private Shell shell;
+	private String calendarName;
 
-	final private Shell shell;
-	private Set<Conference> listeconfuser;
-	
-	/*public GuiListConferences(String loginResearcher) {
-	    Display display = new Display();
-	    this.shell = new Shell(display);
-	    shell.setText("Shell");
-	    shell.setSize(200, 200);
-	    shell.open();
-	}*/
-	
 	/**
-	 * Create a shell where they will have conferences of the user
+	 * Create a GUI where they will have conferences of the user
+	 * @throws ParseException 
+	 * @throws ParserException 
+	 * @throws IOException 
+	 * @throws NumberFormatException 
+	 * @throws InvalidConferenceFormatException 
 	 */
-	public GuiListConferences() {
-	    Display display = new Display();
-		FillLayout layout = new FillLayout(SWT.VERTICAL);
+	public GuiListConferences() throws IOException, ParserException, InvalidConferenceFormatException {
+		calendarName="threeConferences";
+	    Display display=new Display();
+	    shell=createShell(display);
+	    shell.open();
+
+	}
+	
+	/** Create a shell with all field of a conference and a list of conferences
+	 * of a file
+	 * @param display
+	 * @return the shell
+	 * @throws NumberFormatException
+	 * @throws IOException
+	 * @throws ParserException
+	 * @throws ParseException
+	 * @throws InvalidConferenceFormatException 
+	 */
+	public Shell createShell(Display display) throws IOException, ParserException, InvalidConferenceFormatException {
 	    this.shell = new Shell(display);
 	    shell.setText("My conference");
-		layout.marginHeight = 200;
-		layout.marginWidth = 200;
+		GridLayout layout = new GridLayout(2,false);
 		shell.setLayout(layout);
-	    shell.open();
+		
+		listConferences = new List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
+	    this.getConferences();
+	    GridData gridDatalist = new GridData();
+	    gridDatalist.grabExcessHorizontalSpace = true;
+	    gridDatalist.grabExcessVerticalSpace = true;
+	    //gridDatalist.widthHint = 550;
+	    //gridDatalist.heightHint = 150;
+		listConferences.setLayoutData(gridDatalist);
+		
+		Group groupInfoConf = new Group(shell, SWT.NONE);
+		groupInfoConf.setText ("Details of your conference");
+		GridLayout gridLayoutDetails=new GridLayout(4, false);
+		groupInfoConf.setLayout (gridLayoutDetails);
+		
+		GridData gridData=new GridData();
+		gridData.horizontalSpan=3;
+		gridData.widthHint = 500;
+		gridData.heightHint = 30;
+		
+		Label labelTitle= new Label(groupInfoConf, SWT.NONE);
+		labelTitle.setText("Title :");
+		Text txtTitle = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		txtTitle.setLayoutData(gridData);
+		
+		Label labelUrl= new Label(groupInfoConf, SWT.NONE);
+		labelUrl.setText("URL :");
+		Text txtUrl = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		txtUrl.setLayoutData(gridData);
+		
+		Label labelfee= new Label(groupInfoConf, SWT.NONE);
+		labelfee.setText("Fee :");
+		Text txtRegisFee = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		txtRegisFee.setLayoutData(gridData);
+		
+		Label labelCountry= new Label(groupInfoConf, SWT.NONE);
+		labelCountry.setText("Country :");
+		Text txtCoutry = new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		txtCoutry.setLayoutData(gridData);
+		
+		Label labelCity = new Label(groupInfoConf, SWT.NONE);
+		labelCity.setText("City :");
+		Text txtCity=new Text(groupInfoConf,SWT.SINGLE | SWT.BORDER);
+		txtCity.setLayoutData(gridData);
+		
+		Label labelDateStart = new Label(groupInfoConf, SWT.NONE);
+		labelDateStart.setText("Date start :");
+		DateTime datestart=new DateTime(groupInfoConf, SWT.DEFAULT);
+		datestart.setLayoutData(gridData);
+
+		Label labelDateEnd = new Label(groupInfoConf, SWT.NONE);
+		labelDateEnd.setText("Date end :");
+		DateTime dateend=new DateTime(groupInfoConf, SWT.DEFAULT);
+		dateend.setLayoutData(gridData);
+		
+		Button btnsave=new Button(groupInfoConf, SWT.PUSH);
+		btnsave.setText("Save Conference");
+		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
+		btnsave.setLayoutData(gridDataBtn);
+	
+
+		listConferences.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (listConferences.getSelectionIndex()>=0) {
+					Conference conferenceSelected;
+					conferenceSelected=listConferencesUser.get(listConferences.getSelectionIndex());
+					txtTitle.setText(conferenceSelected.getTitle());
+					txtCity.setText(conferenceSelected.getCity());
+					txtCoutry.setText(conferenceSelected.getCountry());
+					txtUrl.setText(conferenceSelected.getUrl().toString());
+					txtRegisFee.setText(conferenceSelected.getFeeRegistration().toString());
+					setDateofConf(datestart,conferenceSelected.getStartDate());
+					setDateofConf(dateend,conferenceSelected.getEndDate());
+				}
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+			
+		});
+		
+		btnsave.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				
+				//edit of a conference
+				if(isDateValid(datestart, dateend)&& listConferences.getSelectionIndex()>=0) {
+					//ConferenceWriter.deleteConference(listConferencesUser.get(listConferences.getSelectionIndex()));
+					//ConferenceWriter.addConference(new conference(.........));
+					listConferences.removeAll();
+					try {
+						getConferences();
+					} catch (NumberFormatException | IOException | ParserException|InvalidConferenceFormatException e1) {
+						e1.printStackTrace();
+					}
+				}
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {				
+			}
+		});
+		
+		return shell;
 	}
 	
 	/**
@@ -47,27 +176,15 @@ public class GuiListConferences {
 	 */
 	public void display() {
 		this.shell.pack();
-
 		this.shell.open();
-
 		while (!this.shell.isDisposed())
-
 		{
 			if (!shell.getDisplay().readAndDispatch()) {
 				shell.getDisplay().sleep();
-
 			}
-
 		}
 	}
-	
-	public static void main(String[]args) throws NumberFormatException, IOException, ParserException, ParseException, InvalidConferenceFormatException{
-		GuiListConferences guil=new GuiListConferences();
-		guil.getconferences();
-		guil.display();
 		
-	}
-	
 	/**
 	 * We retrieve and display in a list the conferences stored in the ical file of the identified user.
 	 * @throws NumberFormatException
@@ -76,17 +193,46 @@ public class GuiListConferences {
 	 * @throws ParseException
 	 * @throws InvalidConferenceFormatException 
 	 */
-	public void getconferences() throws IOException, ParserException, InvalidConferenceFormatException {
-		String calendarName="threeConferences";
+	public void getConferences() throws IOException, ParserException, InvalidConferenceFormatException {
 		ConferencesRetriever retriever = new ConferencesFromICal();
 		ConferencesShower conflist=new ConferencesShower(retriever);
-		this.listeconfuser=conflist.searchConferenceInFile(calendarName);
-		final List list = new List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
-	    for (Conference conf: this.listeconfuser) {
-	      list.add(conf.toString());
+		listConferencesUser=new ArrayList<Conference>(conflist.searchConferenceInFile(this.calendarName));
+	    for (Conference conf: this.listConferencesUser) {
+	      listConferences.add(conf.getTitle());
 	    }
 	}
- 
+	
+	/** this method implement the date of a conference in the good format in the GUI
+	 * @param fieldDate field of the GUI
+	 * @param dateread date of the conference
+	 */
+	public void setDateofConf(DateTime fieldDate,LocalDate dateread) {
+		fieldDate.setDate(dateread.getYear(), dateread.getMonthValue()-1, dateread.getDayOfMonth());
+	}
+	
+	/**This method check the validity of date choose by the searcher :
+	 * Date of start < of Date of End 
+	 * @param datestart field that contains the start date of the conference
+	 * @param dateend field that contains the end date of the conference
+	 * @return
+	 */
+	public boolean isDateValid(DateTime datestart,DateTime dateend) {
+		LocalDate lstart=LocalDate.of(datestart.getYear(), datestart.getMonth()+1, datestart.getDay());
+		LocalDate leend=LocalDate.of(dateend.getYear(), dateend.getMonth()+1, dateend.getDay());
+		if (lstart.compareTo(leend)>0||lstart.compareTo(leend)==0) {
+			LOGGER.debug("conference not save : startday > enday");
+			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
+			mb.setText("Failed");
+			mb.setMessage("Date Start can't be lower or equal to Date End");
+			mb.open();
+			return false;
+		}
+		return true;
+	}
+	
+	public static void main(String[]args) throws IOException, ParserException, InvalidConferenceFormatException{
+		new GuiListConferences().display();
+	}
 }
 
 

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -31,8 +31,17 @@ import com.google.common.base.Strings;
  */
 public class GuiListConferences {
 	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
+	
+	/**
+	 *  Arraylist that stock all of conferences from ConferenceReader
+	 */
 	private ArrayList<Conference> listConferencesUser;
+	
+	/**
+	 * SWT list uses for print all conferences in the GUI
+	 */
 	private List listConferences;
+	
 	private Shell shell;
 	private String calendarName;
 	
@@ -64,7 +73,7 @@ public class GuiListConferences {
 	}
 	
 	/** Create a shell with all field of a conference and the list of conferences
-	 * of a file
+	 * of a specific calendar file
 	 * @param display
 	 * @return the shell
 	 * @throws NumberFormatException
@@ -139,7 +148,8 @@ public class GuiListConferences {
 		VerifyListener verifyListenerLetter=new VerifyListener() {
 			
 			/**
-			 *check if the character is a letter or - or a whitespace
+			 *check if the character is a letter or "-" or a whitespace, 
+			 *if not you can't put the character
 			 */
 			@Override
 			public void verifyText(VerifyEvent e) {
@@ -203,9 +213,6 @@ public class GuiListConferences {
 						e1.printStackTrace();
 					}
 				}
-				else {
-
-				}
 			}
 			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {				
@@ -254,8 +261,8 @@ public class GuiListConferences {
 		fieldDate.setDate(dateRead.getYear(), dateRead.getMonthValue()-1, dateRead.getDayOfMonth());
 	}
 	
-	/**This method check the validity of date choose by the searcher :
-	 * Date of start < of Date of End 
+	/**This method check the validity of a date choose by the searcher :
+	 * Date of start must be < of Date of End 
 	 * @return
 	 */
 	public boolean isDateValid() {
@@ -272,18 +279,17 @@ public class GuiListConferences {
 		return true;
 	}
 	
-	/** Check that all text fields are fill in
-	 * @return a boolean that say if all fields are fill
+	/** Check that all text fields are filled
+	 * @return a boolean that say if all fields are filled
 	 */
 	public boolean isFillIn() {
-		
 		if((Strings.isNullOrEmpty(txtCity.getText())
 				||Strings.isNullOrEmpty(txtUrl.getText())
 				||Strings.isNullOrEmpty(txtCoutry.getText())
 				||Strings.isNullOrEmpty(txtTitle.getText())
 				||Strings.isNullOrEmpty(txtRegisFee.getText()))){
 			
-			LOGGER.debug("conference not save : not all fields filled");
+			LOGGER.debug("Conference not save : not all fields filled");
 			MessageBox mb = new MessageBox(shell, SWT.ICON_INFORMATION | SWT.OK);
 			mb.setText("Failed");
 			mb.setMessage("Conference not save : not all fields filled");
@@ -293,7 +299,7 @@ public class GuiListConferences {
 		return true;
 	}
 	
-	/** launch all method that check if all fields are filled in correctly
+	/** launch all method that check if all fields are filled correctly
 	 * @return a boolean that say if all is correct or not
 	 */
 	public boolean isAllFieldsValid() {

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -16,7 +17,6 @@ import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
@@ -27,20 +27,21 @@ import com.google.common.primitives.Doubles;
 import com.google.common.base.Strings;
 
 /**
- * @author nikola Gui 
- * uses to show a list of conferences of a searcher and with the possibility to edit it
+ * @author nikola 
+ * This class Gui uses to show a list of conferences of a searcher 
+ * and with the possibility to edit it
  */
 public class GuiListConferences {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
 	/**
-	 * List that stocks all of conferences from ConferenceReader
+	 * List that stocks all of conferences previously collected
 	 */
-	private java.util.List<Conference> listConferencesUser;
+	private List<Conference> listConferencesUser;
 	/**
 	 * SWT Widget list, uses for print all conferences
 	 */
-	private List listConferences;
+	private org.eclipse.swt.widgets.List listConferences;
 	private Shell shell;
 	private String calendarName;
 	/**
@@ -54,15 +55,6 @@ public class GuiListConferences {
 	private DateTime dateStart;
 	private DateTime dateEnd;
 
-	/**
-	 * Create a GUI where they will have conferences of the user
-	 * 
-	 * @throws ParseException
-	 * @throws ParserException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 * @throws InvalidConferenceFormatException
-	 */
 	public GuiListConferences() throws IOException, ParserException, InvalidConferenceFormatException {
 		calendarName = "threeConferences";
 		Display display = new Display();
@@ -88,7 +80,7 @@ public class GuiListConferences {
 		GridLayout layout = new GridLayout(2, false);
 		shell.setLayout(layout);
 
-		listConferences = new List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
+		listConferences = new org.eclipse.swt.widgets.List(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
 		this.getConferences();
 		GridData gridDatalist = new GridData();
 		gridDatalist.grabExcessHorizontalSpace = true;

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -33,12 +33,12 @@ public class GuiListConferences {
 	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
 	
 	/**
-	 *  Arraylist that stock all of conferences from ConferenceReader
+	 *  Arraylist that stocks all of conferences from ConferenceReader
 	 */
 	private ArrayList<Conference> listConferencesUser;
 	
 	/**
-	 * SWT list uses for print all conferences in the GUI
+	 * SWT Widget list, uses for print all conferences
 	 */
 	private List listConferences;
 	
@@ -46,7 +46,7 @@ public class GuiListConferences {
 	private String calendarName;
 	
 	/**
-	 * fields filed fill in by the researcher
+	 * SWT Widget text, fields filed fill in by the researcher
 	 */
 	private Text txtTitle;
 	private Text txtUrl;
@@ -203,7 +203,6 @@ public class GuiListConferences {
 				
 				//edit of a conference
 				if(isAllFieldsValid() && listConferences.getSelectionIndex()>=0) {
-					//dev by other team
 					//ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
 					//ConferenceWriter.addConference(calendarName,new Conference(.........));
 					listConferences.removeAll();
@@ -253,7 +252,8 @@ public class GuiListConferences {
 	    }
 	}
 	
-	/** this method implement the date of a conference in the good format in the GUI
+	/** this method implement the date of a conference 
+	 * in the good format in the widget Datetime of the GUI
 	 * @param fieldDate field of the GUI
 	 * @param dateRead date of the conference
 	 */

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -27,7 +27,7 @@ import com.google.common.primitives.Doubles;
 import com.google.common.base.Strings;
 /**
  * @author nikola
- *Gui where we can show conferences of a user
+ *Gui uses to show a list of conferences of a searcher and with the possibility to edit it
  */
 public class GuiListConferences {
 	private static final Logger LOGGER = LoggerFactory.getLogger(GuiListConferences.class);
@@ -236,7 +236,8 @@ public class GuiListConferences {
 	}
 		
 	/**
-	 * We retrieve and display in a list the conferences stored in the ical file of the identified user.
+	 * We retrieve the conferences stored in the iCalendar file of the searcher
+	 * and display it in a SWT widget list 
 	 * @throws NumberFormatException
 	 * @throws IOException
 	 * @throws ParserException
@@ -252,7 +253,7 @@ public class GuiListConferences {
 	    }
 	}
 	
-	/** this method implement the date of a conference 
+	/** this method change the date of a conference 
 	 * in the good format in the widget Datetime of the GUI
 	 * @param fieldDate field of the GUI
 	 * @param dateRead date of the conference

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.events.VerifyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -21,7 +23,7 @@ import org.eclipse.swt.widgets.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.fortuna.ical4j.data.ParserException;
-
+import com.google.common.primitives.Doubles;
 /**
  * @author nikola
  *Gui where we can show conferences of a user
@@ -122,7 +124,19 @@ public class GuiListConferences {
 		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
 		btnSave.setLayoutData(gridDataBtn);
 	
-
+		txtRegisFee.addVerifyListener(new VerifyListener() {
+			
+			/**
+			 *check that the fee is a double, if not you can't put the character
+			 */
+			@Override
+			public void verifyText(VerifyEvent e) {
+				if (Doubles.tryParse(txtRegisFee.getText()+e.text)==null) {
+					e.doit=false;
+				}				
+			}
+		});
+		
 		listConferences.addSelectionListener(new SelectionListener() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -152,8 +166,8 @@ public class GuiListConferences {
 				//edit of a conference
 				if(isDateValid(dateStart, dateEnd)&& listConferences.getSelectionIndex()>=0) {
 					//dev by other team
-					//ConferenceWriter.deleteConference(listConferencesUser.get(listConferences.getSelectionIndex()));
-					//ConferenceWriter.addConference(new conference(.........));
+					//ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
+					//ConferenceWriter.addConference(calendarName,new Conference(.........));
 					listConferences.removeAll();
 					try {
 						getConferences();

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/GuiListConferences.java
@@ -167,10 +167,9 @@ public class GuiListConferences {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
-				// edit of a conference
+				/* edit of a conference: delete and save the conference edited */
 				if (isAllFieldsValid() && listConferences.getSelectionIndex() >= 0) {
-					// ConferenceWriter.deleteConference(calendarName,listConferencesUser.get(listConferences.getSelectionIndex()));
-					// ConferenceWriter.addConference(calendarName,new Conference(.........));
+					LOGGER.warn("Save of Conference not yet implemented");
 					listConferences.removeAll();
 					try {
 						getConferences();

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListenerAction.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListenerAction.java
@@ -10,13 +10,13 @@ import com.google.common.primitives.Doubles;
  * @author nikola
  * Class that contains common methods for verification of text fields
  */
-public class ListennerAction {
+public class ListenerAction {
 	
 	/**
 	 * check if the character is a letter or "-" or a whitespace, if not you can't
 	 * put the character
 	 */
-	public static void CheckTextInput(VerifyEvent e) {
+	public static void checkTextInput(VerifyEvent e) {
 		if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
 			e.doit = false;
 		}
@@ -25,7 +25,7 @@ public class ListennerAction {
 	/**
 	 * check that the fee is a double, if not you can't put the character
 	 */
-	public static void CheckDoubleInput(VerifyEvent e) {
+	public static void checkDoubleInput(VerifyEvent e) {
 		Text txtOfField=(Text) e.widget;
 		if (Doubles.tryParse(txtOfField.getText()+e.text) == null) {
 			e.doit = false;

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListennerAction.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListennerAction.java
@@ -1,0 +1,30 @@
+package io.github.oliviercailloux.y2018.jconfs;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.widgets.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.primitives.Doubles;
+
+public class ListennerAction {
+	
+	/**
+	 * check if the character is a letter or "-" or a whitespace, if not you can't
+	 * put the character
+	 */
+	public static void CheckTextInput(VerifyEvent e) {
+		if (!e.text.matches("[a-zA-ZÀ-ú -]*")) {
+			e.doit = false;
+		}
+	}
+	
+	/**
+	 * check that the fee is a double, if not you can't put the character
+	 */
+	public static void CheckDoubleInput(VerifyEvent e) {
+		Text txtOfField=(Text) e.widget;
+		if (Doubles.tryParse(txtOfField.getText()+e.text) == null) {
+			e.doit = false;
+		}
+	}
+}

--- a/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListennerAction.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/jconfs/ListennerAction.java
@@ -6,6 +6,10 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.primitives.Doubles;
 
+/**
+ * @author nikola
+ * Class that contains common methods for verification of text fields
+ */
 public class ListennerAction {
 	
 	/**


### PR DESCRIPTION
Cette PR est dans la continuité de la PR #3 qui pour rappelle avait pour but (entres autres) de mettre en place les méthodes permettant de lire l'ensemble des conférences d'un fichier icalendar ( et non seulement une comme autrefois). 
Ainsi cette PR s'oriente plus sur l'interface graphique et les pré-conditions de saisie:
-Utilisation de Gridlayout pour disposition des widgets.
-Synchronisation entre la widget liste de SWT et les champs ( lors du clique sur une conférence présente dans la liste, affichage des différentes informations de cette conférence dans différents widgets adaptés (texte et datetime)
-Vérification du respect du bon format de saisie pour chaque édition de conférence et envoie d'un message en cas de mauvais format.
La méthode permettant de rendre effective la modification d'une conférence (delete + create) au sein d'un fichier iCalendar est réalisée par l'autre team de développement.