### PR TITLE
Livraison 4 : Ajout et édition et suppression de conférence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>com.github.caldav4j</groupId>
 			<artifactId>caldav4j</artifactId>
-			<version>0.9.2</version>
+			<version>1.0.0-rc.2</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/junit/junit -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,10 @@
 		<dependency>
 			<groupId>com.github.caldav4j</groupId>
 			<artifactId>caldav4j</artifactId>
-			<version>1.0.0-rc.2</version>
+			<!-- The use of the RC version is mandatory 
+			in order to use the methods of adding and
+			deleting online events -->
+			<version>1.0.0-rc.2</version> 
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/junit/junit -->
 		<dependency>

--- a/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
@@ -1,10 +1,12 @@
 package io.github.oliviercailloux.jconfs.calendar;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.net.URISyntaxException;
 import java.rmi.server.UID;
 import java.text.ParseException;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 
@@ -24,17 +26,29 @@ import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.PropertyList;
 
-import org.apache.commons.httpclient.HostConfiguration;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.osaf.caldav4j.CalDAVCollection;
-import org.osaf.caldav4j.CalDAVConstants;
-import org.osaf.caldav4j.exceptions.CalDAV4JException;
-import org.osaf.caldav4j.methods.CalDAV4JMethodFactory;
-import org.osaf.caldav4j.methods.HttpClient;
-import org.osaf.caldav4j.model.request.CalendarQuery;
-import org.osaf.caldav4j.util.GenerateQuery;
-import org.osaf.caldav4j.util.ICalendarUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import com.github.caldav4j.CalDAVCollection;
+import com.github.caldav4j.CalDAVConstants;
+import com.github.caldav4j.exceptions.CalDAV4JException;
+import com.github.caldav4j.methods.CalDAV4JMethodFactory;
+import com.github.caldav4j.model.request.CalendarQuery;
+import com.github.caldav4j.util.GenerateQuery;
+import com.github.caldav4j.util.ICalendarUtils;
 
 import io.github.oliviercailloux.jconfs.conference.Conference;
 import io.github.oliviercailloux.jconfs.conference.ConferenceReader;
@@ -48,20 +62,20 @@ public class CalendarOnline {
 	final private static String userNameFruux = "b3297431258";
 	final private static String passwordFruux = "jizbr5fuj9gi";
 	final private static String calendarIDFruux = "6e8c6372-eba5-43da-9eed-8e5413559c99";
-	private static HttpClient httpClient;
 	private static CalendarOnline instanceCalendarOnline;
 	private CalDAVCollection collectionCalendarsOnline;
+    private static CloseableHttpClient httpclient;
 
 	private CalendarOnline() {
-		httpClient = new HttpClient();
-		httpClient.getHostConfiguration().setHost("dav.fruux.com", 443, "https");
-		UsernamePasswordCredentials httpCredentials = new UsernamePasswordCredentials(userNameFruux, passwordFruux);
-		httpClient.getState().setCredentials(AuthScope.ANY, httpCredentials);
-		httpClient.getParams().setAuthenticationPreemptive(true);
+		HttpHost hostTarget;
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(new AuthScope("dav.fruux.com", 443),
+                new UsernamePasswordCredentials(userNameFruux, passwordFruux));
+        httpclient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
+        hostTarget = new HttpHost("dav.fruux.com", 443, "https");
 
-		collectionCalendarsOnline = new CalDAVCollection("/calendars/" + userNameFruux + "/" + calendarIDFruux,
-				(HostConfiguration) httpClient.getHostConfiguration().clone(), new CalDAV4JMethodFactory(),
-				CalDAVConstants.PROC_ID_DEFAULT);
+        collectionCalendarsOnline = new CalDAVCollection("/calendars/" + userNameFruux + "/" + calendarIDFruux,
+                hostTarget, new CalDAV4JMethodFactory(), CalDAVConstants.PROC_ID_DEFAULT);
 	}
 
 	public static CalendarOnline getInstance() {
@@ -83,7 +97,7 @@ public class CalendarOnline {
 	public Set<Conference> getOnlineConferences() throws CalDAV4JException, InvalidConferenceFormatException {
 		GenerateQuery searchQuery = new GenerateQuery();
 		CalendarQuery calendarQuery = searchQuery.generate();
-		List<Calendar> calendarsResult = collectionCalendarsOnline.queryCalendars(httpClient, calendarQuery);
+		List<Calendar> calendarsResult = collectionCalendarsOnline.queryCalendars(httpclient, calendarQuery);
 		Set<Conference> listConferencesUser = new LinkedHashSet<>();
 		for (Calendar calendar : calendarsResult) {
 			ComponentList<VEvent> componentList = calendar.getComponents(Component.VEVENT);
@@ -107,7 +121,7 @@ public class CalendarOnline {
 	public void editConferenceOnline(Conference conferenceEdited)
 			throws ParseException, CalDAV4JException, URISyntaxException {
 		VEvent vEventConferenceModified = conferenceToVEvent(conferenceEdited);
-		collectionCalendarsOnline.updateMasterEvent(httpClient, vEventConferenceModified, null);
+		collectionCalendarsOnline.updateMasterEvent(httpclient, vEventConferenceModified, null);
 	}
 
 	/**
@@ -118,12 +132,13 @@ public class CalendarOnline {
 	 */
 	public VEvent conferenceToVEvent(Conference conferenceEdited) throws URISyntaxException, ParseException {
 		VEvent vEventConference;
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 		Property url = new Url(conferenceEdited.getUrl().toURI());
 		Property location = new Location(conferenceEdited.getCity() + "," + conferenceEdited.getCountry());
 		Property description = new Description("Fee:" + conferenceEdited.getFeeRegistration());
 		Property name = new Summary(conferenceEdited.getTitle());
-		Property startDate = new DtStart(conferenceEdited.getEndDate().toString());
-		Property endDate = new DtEnd(conferenceEdited.getStartDate().toString());
+		Property startDate = new DtStart(new Date(conferenceEdited.getStartDate().format(formatter)));
+        Property endDate = new DtEnd(new Date(conferenceEdited.getEndDate().format(formatter)));
 		Property uid = new Uid(conferenceEdited.getUid());
 		PropertyList<Property> propertyListVevent = new PropertyList<>();
 		propertyListVevent.add(url);
@@ -150,11 +165,26 @@ public class CalendarOnline {
 		GenerateQuery searchQuery = new GenerateQuery();
 		searchQuery.setFilter("VEVENT : UID==" + uid);
 		CalendarQuery calendarQuery = searchQuery.generate();
-		List<Calendar> calendarsResult = collectionCalendarsOnline.queryCalendars(httpClient, calendarQuery);
+		List<Calendar> calendarsResult = collectionCalendarsOnline.queryCalendars(httpclient, calendarQuery);
 		for (Calendar calendar : calendarsResult) {
 			vEventConferenceFound = ICalendarUtils.getFirstEvent(calendar);
 		}
 		return ConferenceReader.createConference(vEventConferenceFound);
 	}
+	
+	/**
+     * @param ve event to add
+     * @throws CalDAV4JException
+     * @throws ParseException
+     * @throws URISyntaxException
+     */
+    public void addOnlineConference(Conference conferenceToPush)
+            throws CalDAV4JException, URISyntaxException, ParseException {
+        VEvent ve;
+        ve = conferenceToVEvent(conferenceToPush);
+        Objects.requireNonNull(ve);
+        Objects.requireNonNull(ve.getUid());
+        collectionCalendarsOnline.add(httpclient, ve, null);
+    }
 
 }

--- a/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
@@ -2,6 +2,7 @@ package io.github.oliviercailloux.jconfs.calendar;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.net.URISyntaxException;
 import java.rmi.server.UID;
@@ -161,7 +162,7 @@ public class CalendarOnline {
 	 * @throws CalDAV4JException
 	 * @throws InvalidConferenceFormatException
 	 */
-	public Conference getConferenceFromUid(String uid) throws CalDAV4JException, InvalidConferenceFormatException {
+	public Optional<Conference> getConferenceFromUid(String uid) throws CalDAV4JException, InvalidConferenceFormatException {
 		VEvent vEventConferenceFound = null;
 		GenerateQuery searchQuery = new GenerateQuery();
 		searchQuery.setFilter("VEVENT : UID==" + uid);
@@ -171,9 +172,9 @@ public class CalendarOnline {
 			vEventConferenceFound = ICalendarUtils.getFirstEvent(calendar);
 		}
 		if (vEventConferenceFound == null) {
-			return null;
+			return Optional.empty();
 		}
-		return ConferenceReader.createConference(vEventConferenceFound);
+		return Optional.of(ConferenceReader.createConference(vEventConferenceFound));
 	}
 
 	/**

--- a/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
@@ -55,7 +55,8 @@ import io.github.oliviercailloux.jconfs.conference.ConferenceReader;
 import io.github.oliviercailloux.jconfs.conference.InvalidConferenceFormatException;
 
 /**
- * @author nikola This class permits to access to online conferences from
+ * @author nikola 
+ * This class permits to access to online conferences from
  *         https://fruux.com
  */
 public class CalendarOnline {

--- a/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
@@ -169,6 +169,9 @@ public class CalendarOnline {
 		for (Calendar calendar : calendarsResult) {
 			vEventConferenceFound = ICalendarUtils.getFirstEvent(calendar);
 		}
+		if(vEventConferenceFound==null) {
+            return null;
+        }
 		return ConferenceReader.createConference(vEventConferenceFound);
 	}
 	
@@ -185,6 +188,16 @@ public class CalendarOnline {
         Objects.requireNonNull(ve);
         Objects.requireNonNull(ve.getUid());
         collectionCalendarsOnline.add(httpclient, ve, null);
+    }
+    
+    /**
+     * @param uid uid of the event to delete
+     * @throws CalDAV4JException
+     */
+    public void deleteOnlineConference(String uid) throws CalDAV4JException {
+        Objects.requireNonNull(uid);
+        collectionCalendarsOnline.delete(httpclient,
+                collectionCalendarsOnline.getCalendarCollectionRoot() + "/" + uid + ".ics");
     }
 
 }

--- a/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/calendar/CalendarOnline.java
@@ -55,8 +55,8 @@ import io.github.oliviercailloux.jconfs.conference.ConferenceReader;
 import io.github.oliviercailloux.jconfs.conference.InvalidConferenceFormatException;
 
 /**
- * @author nikola 
- * This class permits to access to online conferences from https://fruux.com
+ * @author nikola This class permits to access to online conferences from
+ *         https://fruux.com
  */
 public class CalendarOnline {
 	final private static String userNameFruux = "b3297431258";
@@ -64,18 +64,18 @@ public class CalendarOnline {
 	final private static String calendarIDFruux = "6e8c6372-eba5-43da-9eed-8e5413559c99";
 	private static CalendarOnline instanceCalendarOnline;
 	private CalDAVCollection collectionCalendarsOnline;
-    private static CloseableHttpClient httpclient;
+	private static CloseableHttpClient httpclient;
 
 	private CalendarOnline() {
 		HttpHost hostTarget;
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(new AuthScope("dav.fruux.com", 443),
-                new UsernamePasswordCredentials(userNameFruux, passwordFruux));
-        httpclient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
-        hostTarget = new HttpHost("dav.fruux.com", 443, "https");
+		CredentialsProvider credsProvider = new BasicCredentialsProvider();
+		credsProvider.setCredentials(new AuthScope("dav.fruux.com", 443),
+				new UsernamePasswordCredentials(userNameFruux, passwordFruux));
+		httpclient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
+		hostTarget = new HttpHost("dav.fruux.com", 443, "https");
 
-        collectionCalendarsOnline = new CalDAVCollection("/calendars/" + userNameFruux + "/" + calendarIDFruux,
-                hostTarget, new CalDAV4JMethodFactory(), CalDAVConstants.PROC_ID_DEFAULT);
+		collectionCalendarsOnline = new CalDAVCollection("/calendars/" + userNameFruux + "/" + calendarIDFruux,
+				hostTarget, new CalDAV4JMethodFactory(), CalDAVConstants.PROC_ID_DEFAULT);
 	}
 
 	public static CalendarOnline getInstance() {
@@ -138,7 +138,7 @@ public class CalendarOnline {
 		Property description = new Description("Fee:" + conferenceEdited.getFeeRegistration());
 		Property name = new Summary(conferenceEdited.getTitle());
 		Property startDate = new DtStart(new Date(conferenceEdited.getStartDate().format(formatter)));
-        Property endDate = new DtEnd(new Date(conferenceEdited.getEndDate().format(formatter)));
+		Property endDate = new DtEnd(new Date(conferenceEdited.getEndDate().format(formatter)));
 		Property uid = new Uid(conferenceEdited.getUid());
 		PropertyList<Property> propertyListVevent = new PropertyList<>();
 		propertyListVevent.add(url);
@@ -169,35 +169,35 @@ public class CalendarOnline {
 		for (Calendar calendar : calendarsResult) {
 			vEventConferenceFound = ICalendarUtils.getFirstEvent(calendar);
 		}
-		if(vEventConferenceFound==null) {
-            return null;
-        }
+		if (vEventConferenceFound == null) {
+			return null;
+		}
 		return ConferenceReader.createConference(vEventConferenceFound);
 	}
-	
+
 	/**
-     * @param ve event to add
-     * @throws CalDAV4JException
-     * @throws ParseException
-     * @throws URISyntaxException
-     */
-    public void addOnlineConference(Conference conferenceToPush)
-            throws CalDAV4JException, URISyntaxException, ParseException {
-        VEvent ve;
-        ve = conferenceToVEvent(conferenceToPush);
-        Objects.requireNonNull(ve);
-        Objects.requireNonNull(ve.getUid());
-        collectionCalendarsOnline.add(httpclient, ve, null);
-    }
-    
-    /**
-     * @param uid uid of the event to delete
-     * @throws CalDAV4JException
-     */
-    public void deleteOnlineConference(String uid) throws CalDAV4JException {
-        Objects.requireNonNull(uid);
-        collectionCalendarsOnline.delete(httpclient,
-                collectionCalendarsOnline.getCalendarCollectionRoot() + "/" + uid + ".ics");
-    }
+	 * @param ve event to add
+	 * @throws CalDAV4JException
+	 * @throws ParseException
+	 * @throws URISyntaxException
+	 */
+	public void addOnlineConference(Conference conferenceToPush)
+			throws CalDAV4JException, URISyntaxException, ParseException {
+		VEvent ve;
+		ve = conferenceToVEvent(conferenceToPush);
+		Objects.requireNonNull(ve);
+		Objects.requireNonNull(ve.getUid());
+		collectionCalendarsOnline.add(httpclient, ve, null);
+	}
+
+	/**
+	 * @param uid uid of the event to delete
+	 * @throws CalDAV4JException
+	 */
+	public void deleteOnlineConference(String uid) throws CalDAV4JException {
+		Objects.requireNonNull(uid);
+		collectionCalendarsOnline.delete(httpclient,
+				collectionCalendarsOnline.getCalendarCollectionRoot() + "/" + uid + ".ics");
+	}
 
 }

--- a/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
@@ -42,8 +42,8 @@ import com.google.common.base.Strings;
 /**
  * @author nikola 
  * This class GUI uses to show a list of conferences of a
- *         searcher and with the possibility to edit it It takes conferences
- *         from fruux
+ *         searcher and with the possibility to edit it.
+ *         It takes conferences from fruux
  */
 public class GuiListConferences {
 

--- a/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
@@ -40,7 +40,8 @@ import com.github.caldav4j.exceptions.CalDAV4JException;
 import com.google.common.base.Strings;
 
 /**
- * @author nikola This class GUI uses to show a list of conferences of a
+ * @author nikola 
+ * This class GUI uses to show a list of conferences of a
  *         searcher and with the possibility to edit it It takes conferences
  *         from fruux
  */
@@ -295,9 +296,6 @@ public class GuiListConferences {
 		labelDateEnd.setText("Date end :");
 		this.dateEnd = new DateTime(groupInfoConf, SWT.DEFAULT);
 		this.dateEnd.setLayoutData(gridDataTextField);
-
-		btnSave = new Button(groupInfoConf, SWT.PUSH);
-		btnSave.setText("Save Conference");
 
 		btnSave = new Button(groupInfoConf, SWT.PUSH);
 		btnSave.setText("Save Conference");

--- a/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
@@ -40,10 +40,9 @@ import com.github.caldav4j.exceptions.CalDAV4JException;
 import com.google.common.base.Strings;
 
 /**
- * @author nikola 
- * This class GUI uses to show a list of conferences of a
- * searcher and with the possibility to edit it
- * It takes conferences from fruux
+ * @author nikola This class GUI uses to show a list of conferences of a
+ *         searcher and with the possibility to edit it It takes conferences
+ *         from fruux
  */
 public class GuiListConferences {
 
@@ -68,9 +67,9 @@ public class GuiListConferences {
 	private DateTime dateStart;
 	private DateTime dateEnd;
 	private Button btnSave;
-    private Button btnClear;
-    private Button btnDelete;
-    
+	private Button btnClear;
+	private Button btnDelete;
+
 	public GuiListConferences() throws InvalidConferenceFormatException {
 		Display display = new Display();
 		shell = createShell(display);
@@ -214,27 +213,27 @@ public class GuiListConferences {
 	}
 
 	/**
-     * Edit and add a conference:
-     * Delete from fruux the current selected conference by the user
-     * and add a new conference with the value enter by the user
-     * The widget list is updates with new online conferences
-     * @param e event that we catch
-     */
-    public void editConference(@SuppressWarnings("unused") Event e) {
-        if (isAllFieldsValid()) {
-            if (listConferences.getSelectionIndex() >= 0) {
-                removeConference();
-            }
-            addConference();
-            listConferences.removeAll();
-            listConferences.deselectAll();
-            try {
-                getConferences();
-            } catch (InvalidConferenceFormatException e1) {
-                throw new IllegalStateException(e1);
-            }
-        }
-    }
+	 * Edit and add a conference: Delete from fruux the current selected conference
+	 * by the user and add a new conference with the value enter by the user The
+	 * widget list is updates with new online conferences
+	 * 
+	 * @param e event that we catch
+	 */
+	public void editConference(@SuppressWarnings("unused") Event e) {
+		if (isAllFieldsValid()) {
+			if (listConferences.getSelectionIndex() >= 0) {
+				removeConference();
+			}
+			addConference();
+			listConferences.removeAll();
+			listConferences.deselectAll();
+			try {
+				getConferences();
+			} catch (InvalidConferenceFormatException e1) {
+				throw new IllegalStateException(e1);
+			}
+		}
+	}
 
 	/**
 	 * Create widgets of the GUI, and disposition of widgets
@@ -299,20 +298,20 @@ public class GuiListConferences {
 
 		btnSave = new Button(groupInfoConf, SWT.PUSH);
 		btnSave.setText("Save Conference");
-		
+
 		btnSave = new Button(groupInfoConf, SWT.PUSH);
-        btnSave.setText("Save Conference");
-        GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
-        gridDataBtn.widthHint=200;
-        btnSave.setLayoutData(gridDataBtn);
-       
-        btnDelete = new Button(groupInfoConf, SWT.PUSH);
-        btnDelete.setText("Delete Conference");
-        btnDelete.setLayoutData(gridDataBtn);
-       
-        btnClear = new Button(groupInfoConf, SWT.PUSH);
-        btnClear.setText("Clear fields");
-        btnClear.setLayoutData(gridDataBtn);
+		btnSave.setText("Save Conference");
+		GridData gridDataBtn = new GridData(SWT.RIGHT, SWT.BOTTOM, false, false);
+		gridDataBtn.widthHint = 200;
+		btnSave.setLayoutData(gridDataBtn);
+
+		btnDelete = new Button(groupInfoConf, SWT.PUSH);
+		btnDelete.setText("Delete Conference");
+		btnDelete.setLayoutData(gridDataBtn);
+
+		btnClear = new Button(groupInfoConf, SWT.PUSH);
+		btnClear.setText("Clear fields");
+		btnClear.setLayoutData(gridDataBtn);
 	}
 
 	/**
@@ -325,77 +324,79 @@ public class GuiListConferences {
 		listConferences.addListener(SWT.Selection, this::fillInAllFields);
 		btnSave.addListener(SWT.Selection, this::editConference);
 		btnClear.addListener(SWT.Selection, this::clearwidget);
-        btnDelete.addListener(SWT.Selection, this::deleteConference);
+		btnDelete.addListener(SWT.Selection, this::deleteConference);
 	}
 
 	public static void main(String[] args) throws InvalidConferenceFormatException {
 		new GuiListConferences().display();
 	}
-	
+
 	/**
-     * Delete the conference in fruux that had been selected by the user
-     * @param e vent that we catch
-     */
-    public void deleteConference(@SuppressWarnings("unused") Event e) {
-        if (listConferences.getSelectionIndex() >= 0) {
-            removeConference();
-        }
-        listConferences.removeAll();
-        listConferences.deselectAll();
-        try {
-            getConferences();
-        } catch (InvalidConferenceFormatException e1) {
-            throw new IllegalStateException(e1);
-        }
-    }
- 
-    /**
-     * Clear all widgets of the GUI
-     * @param e
-     */
-    public void clearwidget(@SuppressWarnings("unused") Event e) {
-        txtCity.setText("");
-        txtCoutry.setText("");
-        txtRegisFee.setText("");
-        txtTitle.setText("");
-        txtUrl.setText("");
-        listConferences.deselectAll();
-    }
- 
-    /**
-     * Call the method from CalendarOnline to push in fruux the new conference
-     */
-    public void addConference() {
-        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
-        LocalDate localDateStart = LocalDate.of(dateStart.getYear(), dateStart.getMonth() + 1, dateStart.getDay());
-        LocalDate localDateEnd = LocalDate.of(dateEnd.getYear(), dateEnd.getMonth() + 1, dateEnd.getDay());
-        URL urlConference;
-        try {
-            urlConference = new URL(txtUrl.getText());
-        } catch (MalformedURLException e1) {
-            throw new IllegalStateException(e1);
-        }
- 
-        Conference newConference = new Conference(new RandomUidGenerator().generateUid().getValue(), urlConference,
-                txtTitle.getText(), localDateStart, localDateEnd, Doubles.tryParse(txtRegisFee.getText()),
-                txtCoutry.getText(), txtCity.getText());
-        try {
-            instanceCalendarOnline.addOnlineConference(newConference);
-        } catch (CalDAV4JException | URISyntaxException | ParseException e) {
-            throw new IllegalStateException(e);
-        }
-    }
- 
-    /**
-     * Call the method from CalendarOnline to delete in fruux a conference
-     */
-    public void removeConference() {
-        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
-        String uidDelete = listConferencesUser.get(listConferences.getSelectionIndex()).getUid();
-        try {
-            instanceCalendarOnline.deleteOnlineConference(uidDelete);
-        } catch (CalDAV4JException e) {
-            throw new IllegalStateException(e);
-        }
-    }
+	 * Delete the conference in fruux that had been selected by the user
+	 * 
+	 * @param e vent that we catch
+	 */
+	public void deleteConference(@SuppressWarnings("unused") Event e) {
+		if (listConferences.getSelectionIndex() >= 0) {
+			removeConference();
+		}
+		listConferences.removeAll();
+		listConferences.deselectAll();
+		try {
+			getConferences();
+		} catch (InvalidConferenceFormatException e1) {
+			throw new IllegalStateException(e1);
+		}
+	}
+
+	/**
+	 * Clear all widgets of the GUI
+	 * 
+	 * @param e
+	 */
+	public void clearwidget(@SuppressWarnings("unused") Event e) {
+		txtCity.setText("");
+		txtCoutry.setText("");
+		txtRegisFee.setText("");
+		txtTitle.setText("");
+		txtUrl.setText("");
+		listConferences.deselectAll();
+	}
+
+	/**
+	 * Call the method from CalendarOnline to push in fruux the new conference
+	 */
+	public void addConference() {
+		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+		LocalDate localDateStart = LocalDate.of(dateStart.getYear(), dateStart.getMonth() + 1, dateStart.getDay());
+		LocalDate localDateEnd = LocalDate.of(dateEnd.getYear(), dateEnd.getMonth() + 1, dateEnd.getDay());
+		URL urlConference;
+		try {
+			urlConference = new URL(txtUrl.getText());
+		} catch (MalformedURLException e1) {
+			throw new IllegalStateException(e1);
+		}
+
+		Conference newConference = new Conference(new RandomUidGenerator().generateUid().getValue(), urlConference,
+				txtTitle.getText(), localDateStart, localDateEnd, Doubles.tryParse(txtRegisFee.getText()),
+				txtCoutry.getText(), txtCity.getText());
+		try {
+			instanceCalendarOnline.addOnlineConference(newConference);
+		} catch (CalDAV4JException | URISyntaxException | ParseException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	/**
+	 * Call the method from CalendarOnline to delete in fruux a conference
+	 */
+	public void removeConference() {
+		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+		String uidDelete = listConferencesUser.get(listConferences.getSelectionIndex()).getUid();
+		try {
+			instanceCalendarOnline.deleteOnlineConference(uidDelete);
+		} catch (CalDAV4JException e) {
+			throw new IllegalStateException(e);
+		}
+	}
 }

--- a/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
+++ b/src/main/java/io/github/oliviercailloux/jconfs/gui/GuiListConferences.java
@@ -21,7 +21,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
-import org.osaf.caldav4j.exceptions.CalDAV4JException;
 import org.eclipse.swt.widgets.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +31,7 @@ import io.github.oliviercailloux.jconfs.calendar.CalendarOnline;
 import io.github.oliviercailloux.jconfs.conference.Conference;
 import io.github.oliviercailloux.jconfs.conference.InvalidConferenceFormatException;
 
+import com.github.caldav4j.exceptions.CalDAV4JException;
 import com.google.common.base.Strings;
 
 /**

--- a/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
@@ -7,11 +7,13 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +34,21 @@ public class TestCalendarOnline {
 	public void testGetOnlineConferenceFromUid()
 			throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
-		Conference conferenceFound;
 		String uidSearch = "b8e5f0dc-5a69-4fd5-bde3-f38e0f986085";
-		conferenceFound = instanceCalendarOnline.getConferenceFromUid(uidSearch);
-		assertEquals(conferenceFound.getTitle(), "Java presentation");
-		assertEquals(conferenceFound.getUid(), uidSearch);
-		assertEquals(conferenceFound.getCity(), "Paris");
-		assertEquals(conferenceFound.getCountry(), "France");
-		assertEquals(conferenceFound.getStartDate().toString(), "2019-07-01");
-		assertEquals(conferenceFound.getFeeRegistration().toString(), "1.36");
+		Optional<Conference> potentialConference;
+		potentialConference = instanceCalendarOnline.getConferenceFromUid(uidSearch);
+		if (potentialConference.isPresent()) {
+			Conference conferenceFound = potentialConference.get();
+			assertEquals("Java presentation",conferenceFound.getTitle());
+			assertEquals(uidSearch,conferenceFound.getUid());
+			assertEquals("Paris",conferenceFound.getCity());
+			assertEquals("France",conferenceFound.getCountry());
+			assertEquals("2019-07-01",conferenceFound.getStartDate().toString());
+			assertEquals("1.36",conferenceFound.getFeeRegistration().toString());
+		}
+		else {
+			fail(new NullPointerException());
+		}		
 	}
 
 	@Test
@@ -93,7 +101,7 @@ public class TestCalendarOnline {
 
 	@Test
 	public void testAddOnlineConference() throws MalformedURLException, URISyntaxException, ParseException,
-			InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
+	InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		LocalDate start_ = null;
 		LocalDate end_ = null;
@@ -108,8 +116,11 @@ public class TestCalendarOnline {
 		Conference conference = new Conference(uid, new URL("http://fruux.com"), "Java formation", start_, end_, 1.36,
 				"France", "Paris");
 		instanceCalendarOnline.addOnlineConference(conference);
-		Conference confTest = instanceCalendarOnline.getConferenceFromUid(uid);
-		assertNotNull(confTest);
+		Optional<Conference> confTest = instanceCalendarOnline.getConferenceFromUid(uid);
+		if(!confTest.isPresent()) {
+			fail();
+		}
+
 	}
 
 	@Test
@@ -117,7 +128,9 @@ public class TestCalendarOnline {
 		String uid = "4e14d618-1d93-29a3-adb3-2c21dca5ee67";
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		instanceCalendarOnline.deleteOnlineConference(uid);
-		assertNull(instanceCalendarOnline.getConferenceFromUid(uid));
+		if(instanceCalendarOnline.getConferenceFromUid(uid).isPresent()) {
+			fail();
+		}
 
 	}
 

--- a/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
@@ -27,9 +27,10 @@ import net.fortuna.ical4j.model.property.DtEnd;
 import net.fortuna.ical4j.model.property.DtStart;
 
 public class TestCalendarOnline {
-	
+
 	@Test
-	public void testGetOnlineConferenceFromUid() throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
+	public void testGetOnlineConferenceFromUid()
+			throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		Conference conferenceFound;
 		String uidSearch = "7aa11ba6-e6d7-452e-b60c-8d50a5520107";
@@ -43,7 +44,8 @@ public class TestCalendarOnline {
 	}
 
 	@Test
-	public void testGetAllOnlineConferences() throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
+	public void testGetAllOnlineConferences()
+			throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		Set<Conference> collectionConferences = instanceCalendarOnline.getOnlineConferences();
 		Iterator<Conference> iteratorConf = collectionConferences.iterator();
@@ -88,35 +90,35 @@ public class TestCalendarOnline {
 		assertEquals(conferenceVEvent.getProperty(Property.DESCRIPTION).getValue(),
 				"Fee:" + conference.getFeeRegistration());
 	}
-	
+
 	@Test
-    public void testAddOnlineConference()
-            throws MalformedURLException, URISyntaxException, ParseException, InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
-        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
-        LocalDate start_ = null;
-        LocalDate end_ = null;
-        String uid="4e14d618-1d93-29a3-adb3-2c21dca5ee67";
-        try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-            start_ = LocalDate.parse("06/08/2019", formatter);
-            end_ = LocalDate.parse("08/08/2019", formatter);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Date impossible to put in the conference", e);
-        }
-        Conference conference = new Conference(uid, new URL("http://fruux.com"),
-                "Java formation", start_, end_, 1.36, "France", "Paris");
-        instanceCalendarOnline.addOnlineConference(conference);
-        Conference confTest=instanceCalendarOnline.getConferenceFromUid(uid);
-        assertNotNull(confTest);
-    }
-	
+	public void testAddOnlineConference() throws MalformedURLException, URISyntaxException, ParseException,
+			InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
+		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+		LocalDate start_ = null;
+		LocalDate end_ = null;
+		String uid = "4e14d618-1d93-29a3-adb3-2c21dca5ee67";
+		try {
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+			start_ = LocalDate.parse("06/08/2019", formatter);
+			end_ = LocalDate.parse("08/08/2019", formatter);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Date impossible to put in the conference", e);
+		}
+		Conference conference = new Conference(uid, new URL("http://fruux.com"), "Java formation", start_, end_, 1.36,
+				"France", "Paris");
+		instanceCalendarOnline.addOnlineConference(conference);
+		Conference confTest = instanceCalendarOnline.getConferenceFromUid(uid);
+		assertNotNull(confTest);
+	}
+
 	@Test
-    public void testDelete() throws InvalidConferenceFormatException, CalDAV4JException {
-        String uid="4e14d618-1d93-29a3-adb3-2c21dca5ee67";
-        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
-        instanceCalendarOnline.deleteOnlineConference(uid);
-        assertNull(instanceCalendarOnline.getConferenceFromUid(uid));
-       
-    }
+	public void testDelete() throws InvalidConferenceFormatException, CalDAV4JException {
+		String uid = "4e14d618-1d93-29a3-adb3-2c21dca5ee67";
+		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+		instanceCalendarOnline.deleteOnlineConference(uid);
+		assertNull(instanceCalendarOnline.getConferenceFromUid(uid));
+
+	}
 
 }

--- a/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
@@ -10,9 +10,12 @@ import java.util.Iterator;
 import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
+import com.github.caldav4j.exceptions.CalDAV4JException;
 
 import io.github.oliviercailloux.jconfs.calendar.CalendarOnline;
 import io.github.oliviercailloux.jconfs.conference.Conference;
@@ -105,6 +108,15 @@ public class TestCalendarOnline {
         instanceCalendarOnline.addOnlineConference(conference);
         Conference confTest=instanceCalendarOnline.getConferenceFromUid(uid);
         assertNotNull(confTest);
+    }
+	
+	@Test
+    public void testDelete() throws InvalidConferenceFormatException, CalDAV4JException {
+        String uid="4e14d618-1d93-29a3-adb3-2c21dca5ee67";
+        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+        instanceCalendarOnline.deleteOnlineConference(uid);
+        assertNull(instanceCalendarOnline.getConferenceFromUid(uid));
+       
     }
 
 }

--- a/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
@@ -9,10 +9,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.osaf.caldav4j.exceptions.CalDAV4JException;
 
 import io.github.oliviercailloux.jconfs.calendar.CalendarOnline;
 import io.github.oliviercailloux.jconfs.conference.Conference;
@@ -24,22 +24,23 @@ import net.fortuna.ical4j.model.property.DtEnd;
 import net.fortuna.ical4j.model.property.DtStart;
 
 public class TestCalendarOnline {
-
-	public void testGetOnlineConferenceFromUid() throws CalDAV4JException, InvalidConferenceFormatException {
+	
+	@Test
+	public void testGetOnlineConferenceFromUid() throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		Conference conferenceFound;
-		String uidSearch = "4e14d618-1d93-40a3-adb9-3c01dca8ee67";
+		String uidSearch = "7aa11ba6-e6d7-452e-b60c-8d50a5520107";
 		conferenceFound = instanceCalendarOnline.getConferenceFromUid(uidSearch);
-		assertEquals(conferenceFound.getTitle(), "Third iteration JAVA");
+		assertEquals(conferenceFound.getTitle(), "Java presentation");
 		assertEquals(conferenceFound.getUid(), uidSearch);
 		assertEquals(conferenceFound.getCity(), "Paris");
 		assertEquals(conferenceFound.getCountry(), "France");
-		assertEquals(conferenceFound.getStartDate().toString(), "2019-06-21");
+		assertEquals(conferenceFound.getStartDate().toString(), "2019-07-01");
 		assertEquals(conferenceFound.getFeeRegistration().toString(), "1.46");
 	}
 
 	@Test
-	public void testGetAllOnlineConferences() throws CalDAV4JException, InvalidConferenceFormatException {
+	public void testGetAllOnlineConferences() throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		Set<Conference> collectionConferences = instanceCalendarOnline.getOnlineConferences();
 		Iterator<Conference> iteratorConf = collectionConferences.iterator();
@@ -83,10 +84,27 @@ public class TestCalendarOnline {
 		assertEquals(conferenceVEvent.getProperty(Property.UID).getValue(), conference.getUid());
 		assertEquals(conferenceVEvent.getProperty(Property.DESCRIPTION).getValue(),
 				"Fee:" + conference.getFeeRegistration());
-		Property startDate_ = new DtStart(conference.getEndDate().toString());
-		Property endDate_ = new DtEnd(conference.getStartDate().toString());
-		assertTrue(conferenceVEvent.getProperty(Property.DTSTART).equals(startDate_));
-		assertTrue(conferenceVEvent.getProperty(Property.DTEND).equals(endDate_));
 	}
+	
+	@Test
+    public void testAddOnlineConference()
+            throws MalformedURLException, URISyntaxException, ParseException, InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
+        CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
+        LocalDate start_ = null;
+        LocalDate end_ = null;
+        String uid="4e14d618-1d93-29a3-adb3-2c21dca5ee67";
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            start_ = LocalDate.parse("06/08/2019", formatter);
+            end_ = LocalDate.parse("08/08/2019", formatter);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Date impossible to put in the conference", e);
+        }
+        Conference conference = new Conference(uid, new URL("http://fruux.com"),
+                "Java formation", start_, end_, 1.36, "France", "Paris");
+        instanceCalendarOnline.addOnlineConference(conference);
+        Conference confTest=instanceCalendarOnline.getConferenceFromUid(uid);
+        assertNotNull(confTest);
+    }
 
 }

--- a/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/TestCalendarOnline.java
@@ -33,14 +33,14 @@ public class TestCalendarOnline {
 			throws InvalidConferenceFormatException, com.github.caldav4j.exceptions.CalDAV4JException {
 		CalendarOnline instanceCalendarOnline = CalendarOnline.getInstance();
 		Conference conferenceFound;
-		String uidSearch = "7aa11ba6-e6d7-452e-b60c-8d50a5520107";
+		String uidSearch = "b8e5f0dc-5a69-4fd5-bde3-f38e0f986085";
 		conferenceFound = instanceCalendarOnline.getConferenceFromUid(uidSearch);
 		assertEquals(conferenceFound.getTitle(), "Java presentation");
 		assertEquals(conferenceFound.getUid(), uidSearch);
 		assertEquals(conferenceFound.getCity(), "Paris");
 		assertEquals(conferenceFound.getCountry(), "France");
 		assertEquals(conferenceFound.getStartDate().toString(), "2019-07-01");
-		assertEquals(conferenceFound.getFeeRegistration().toString(), "1.46");
+		assertEquals(conferenceFound.getFeeRegistration().toString(), "1.36");
 	}
 
 	@Test

--- a/src/test/java/io/github/oliviercailloux/TestConferenceReader.java
+++ b/src/test/java/io/github/oliviercailloux/TestConferenceReader.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.validation.constraints.AssertTrue;
-import org.osaf.caldav4j.exceptions.CalDAV4JException;
 
 import io.github.oliviercailloux.jconfs.calendar.CalendarOnline;
 import io.github.oliviercailloux.jconfs.conference.Conference;

--- a/src/test/java/io/github/oliviercailloux/jconfs/calendar/TestCalendarOnline.java
+++ b/src/test/java/io/github/oliviercailloux/jconfs/calendar/TestCalendarOnline.java
@@ -1,4 +1,4 @@
-package io.github.oliviercailloux;
+package io.github.oliviercailloux.jconfs.calendar;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;


### PR DESCRIPTION
Cette PR fait suite à la PR #24, l'équipe 1 a implémenté les fonctionnalités d'ajout et d'édition de conférences.
Cela a nécessité :  
 - Une montée de version de librairie caldav4j ( et passage vers HttpClient4) obligatoire pour l'ajout de conférence.
- Adapter le code du GUI pour que l’utilisateur puisse envoyer, supprimer et afficher les conférences en ligne.
- Des tests pour les méthodes d'ajout et de suppression ainsi que de modification de conférences.
Cette tâche a occupé l'ensemble de livraison 4 de l'équipe 1.